### PR TITLE
Fix disconnecting client hangs.

### DIFF
--- a/fs-caching-server.js
+++ b/fs-caching-server.js
@@ -18,6 +18,7 @@ var mime = require('mime');
 var mkdirp = require('mkdirp');
 var path = require('path-platform');
 var uuid = require('node-uuid');
+var clone = require("readable-stream-clone");
 
 var package = require('./package.json');
 
@@ -239,8 +240,10 @@ function onrequest(req, res) {
           ores.unpipe(ws);
           finish();
         });
-        ores.pipe(ws);
-        ores.pipe(res);
+        ores_ws = new clone(ores);
+        ores_res = new clone(ores);
+        ores_ws.pipe(ws);
+        ores_res.pipe(res);
       });
     });
     oreq.on('error', function(e) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mkdirp": "^0.5.0",
     "node-uuid": "^1.4.3",
     "path-platform": "^0.11.15",
-    "posix-getopt": "^1.1.0"
+    "posix-getopt": "^1.1.0",
+    "readable-stream-clone": "^0.0.7"
   }
 }


### PR DESCRIPTION
During uncached file downloads the data is piped to two readers, one to
the requesting client, and one to a file system writer to store the new
file in the cache.

However, if the requesting client disconnects, the pipe stalls.  This
results in the pipe that writes to the file system never completing, and
any subsequent requests for the file hang indefinitely waiting for the
in-progress download.  This stays blocked until the entire process is
restarted.

Instead, use the readable-stream-clone module to clone two readable
streams, one for the client and one for the file system, so that they
are no longer dependent on each other.

Tested in various scenarios and confirmed to fix #2, which a number of
pkgbuild users were running into.  It may also improve performance by
separating the pipe write speeds, allowing the file system writer to
return as quickly as possible and permit other clients to request the
newly cached file.